### PR TITLE
Correcting stupid mistakes pt. 1

### DIFF
--- a/QOSF_Bell_State.ipynb
+++ b/QOSF_Bell_State.ipynb
@@ -559,13 +559,13 @@
     "In general, a global phase factor of zero can be maintained by applying some RZ rotation such that it is returned to 0. The phase angle of this gate $\\theta$ can be optimized by a similar AQGD process like the one above. When the RZ gate is not available in the transpiled circuit, the equivalent gate can be achieved from an equivalent series of RX and RY gates:\n",
     "\n",
     "$$\n",
-    "R_Z(\\theta) = e^{-i\\theta/2Z}\n",
-    "= e^{-i\\theta/2(-iXY)}\n",
-    "= e^{-i\\theta/4X}e^{-i\\theta/4Y}\n",
-    "= R_X(\\theta/2)R_Y(\\theta/2)\n",
+    "R_Z(\\theta) = e^{-i\\theta/2}Z\n",
+    "= e^{-i\\theta/2}(-iXY)\n",
+    "= -ie^{-i\\theta/2}Xe^{-i\\theta/2}Y\n",
+    "= R_X(\\theta)R_Y(\\theta)\n",
     "$$\n",
     "\n",
-    "By this decomposition, an RZ operation can be created by an RXRY operation at half the required phase rotation."
+    "By this decomposition, an RZ operation can be created by an RXRY operation at the required phase rotation."
    ]
   }
  ],

--- a/QOSF_Bell_State.ipynb
+++ b/QOSF_Bell_State.ipynb
@@ -296,6 +296,8 @@
    "outputs": [],
    "source": [
     "aqgd = AQGD(maxiter = 500, eta = 2.0, tol = 1e-06, disp = False, momentum = 0.25)\n",
+    "aqgd.wrap_function(circ2, {theta_x_1, theta_y_0})\n",
+    "# This is a placeholder for the real cost function, to be defined by desired statevector amplitude\n",
     "\n",
     "# Conduct optimization of gate angles\n",
     "aqgd.optimize(2, obj_fun(circ), variable_bounds = (0, 2*np.pi), initial_point = [0,0]) "
@@ -463,6 +465,8 @@
    "source": [
     "# AQGD placeholder\n",
     "aqgd2 = AQGD(maxiter = 500, eta = 2.0, tol = 1e-06, disp = False, momentum = 0.25)\n",
+    "aqgd2.wrap_function(circ2, {theta_x_1, theta_y_0})\n",
+    "# This is a placeholder for the real cost function, to be defined by desired statevector amplitude\n",
     "\n",
     "# Conduct optimization of gate angles\n",
     "aqgd2.optimize(2, obj_fun(circ2), variable_bounds = (0, 2*np.pi), initial_point = [0, 0]) "
@@ -562,7 +566,7 @@
     "R_Z(\\theta) = e^{-i\\theta/2}Z\n",
     "= e^{-i\\theta/2}(-iXY)\n",
     "= -ie^{-i\\theta/2}Xe^{-i\\theta/2}Y\n",
-    "= R_X(\\theta)R_Y(\\theta)\n",
+    "= R_X(-\\theta)R_Y(\\theta)\n",
     "$$\n",
     "\n",
     "By this decomposition, an RZ operation can be created by an RXRY operation at the required phase rotation."


### PR DESCRIPTION
Found algebra error in part 5. Runtime errors in actual AQGD optimization need to be fixed as well.

Current behavior: all other cells of notebook execute except for the AQGD cells. This means the circuits are not optimized when regenerated, and they still hold their initial states.

Desired behavior: Parameterized circuit statevectors and measurements should correspond to the model in Pt. 2 following optimization.

Fix by: get AQGD into working state, or rewrite optimization to use different gradient descent method outright.